### PR TITLE
feat: add dark mode theme toggle

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,6 +4,7 @@ import { NeonAuthUIProvider } from '@neondatabase/auth/react/ui';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
+import { ThemeProvider } from 'next-themes';
 import { authClient } from '@/lib/auth-client';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -11,16 +12,18 @@ export function Providers({ children }: { children: ReactNode }) {
   const router = useRouter();
 
   return (
-    <NeonAuthUIProvider
-      authClient={authClient}
-      navigate={router.push}
-      social={{
-        providers: ['github'],
-      }}
-      redirectTo="/tasks"
-      Link={Link}
-    >
-      <TooltipProvider>{children}</TooltipProvider>
-    </NeonAuthUIProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+      <NeonAuthUIProvider
+        authClient={authClient}
+        navigate={router.push}
+        social={{
+          providers: ['github'],
+        }}
+        redirectTo="/tasks"
+        Link={Link}
+      >
+        <TooltipProvider>{children}</TooltipProvider>
+      </NeonAuthUIProvider>
+    </ThemeProvider>
   );
 }

--- a/components/nav/sidebar.tsx
+++ b/components/nav/sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import { CheckSquare, Tag, ListTodo } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { UserMenu } from './user-menu';
+import { ThemeToggle } from './theme-toggle';
 import { Separator } from '@/components/ui/separator';
 
 const navItems = [
@@ -47,8 +48,12 @@ export function Sidebar() {
 
       <Separator />
 
-      {/* User menu at bottom */}
-      <div className="p-3">
+      {/* Theme toggle + user menu at bottom */}
+      <div className="p-3 space-y-1">
+        <div className="flex items-center justify-between px-1">
+          <span className="text-xs text-sidebar-foreground/60 font-medium">Theme</span>
+          <ThemeToggle />
+        </div>
         <UserMenu />
       </div>
     </aside>

--- a/components/nav/theme-toggle.tsx
+++ b/components/nav/theme-toggle.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+          aria-label="Toggle theme"
+        >
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-transform dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-transform dark:rotate-0 dark:scale-100" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        {resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "drizzle-orm": "^0.45.1",
         "lucide-react": "^0.575.0",
         "next": "^16.1.6",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "drizzle-orm": "^0.45.1",
     "lucide-react": "^0.575.0",
     "next": "^16.1.6",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",


### PR DESCRIPTION
## Summary

Implements dark mode support, closing #1.

- **`next-themes` `ThemeProvider`** added to `app/providers.tsx` — defaults to system preference, persists choice to `localStorage`
- **`ThemeToggle` component** (`components/nav/theme-toggle.tsx`) — animated sun/moon icon button in the sidebar footer
- **Zero extra CSS** — all existing shadcn/ui components already use the `.dark` CSS variable tokens defined in `globals.css`
- **No hydration flash** — `suppressHydrationWarning` was already set on `<html>` in `app/layout.tsx`

## Test plan

- [x] TypeScript clean (`tsc --noEmit`)
- [x] ESLint clean (0 errors, 0 warnings)
- [x] Verified dark mode visually with Playwright — sidebar, cards, buttons, and empty states all render correctly in both themes
- [x] Toggle button visible in sidebar bottom, switches theme on click
- [x] Preference survives page reload (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)